### PR TITLE
OSPRH-20573: Add custom inference endpoint support

### DIFF
--- a/gpu-validation/files/scripts/model_performance_check.sh
+++ b/gpu-validation/files/scripts/model_performance_check.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 
+URL="${URL:-http://localhost:8000}"
 MODEL_NAME="${MODEL_NAME:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
+TOKEN="${TOKEN:-}"
 
 function do_curl {
     if [ "$1" == "chat" ]; then
-        CURL_OUTPUT=$(curl -s --show-error -f -X POST "http://localhost:8000/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            --data '{"model": "'"${MODEL_NAME}"'","messages": [{"role": "user","content": "Who am I speaking to?"}]}')
+        local curl_args=(
+            -k -s --show-error -f -X POST "${URL}/v1/chat/completions"
+            -H "Content-Type: application/json"
+        )
+        if [ -n "$TOKEN" ]; then
+            curl_args+=(-H "Authorization: Bearer $TOKEN")
+        fi
+        curl_args+=(--data '{"model": "'"${MODEL_NAME}"'","messages": [{"role": "user","content": "Who am I speaking to?"}]}')
+        CURL_OUTPUT=$(curl "${curl_args[@]}")
     elif [ "$1" == "metrics" ]; then
-        CURL_OUTPUT=$(curl -s --show-error -f localhost:8000/metrics)
+        CURL_OUTPUT=$(curl -k -s --show-error -f "${URL}/metrics")
     fi
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
**What does this PR do?**
Add the possibility of checking the model performance of any inference endpoint.

**Why do we need it?**
To support external or custom inferences URL endpoints. For instance, RHOAI, with its Simplified Model Serving or RHOAI Model Deployment, routes to expose inference endpoints via HTTPS and specific URLs.