### PR TITLE
Allow standard drivers to function for dev type-PF

### DIFF
--- a/gpu-validation/tasks/vm_image.yaml
+++ b/gpu-validation/tasks/vm_image.yaml
@@ -36,4 +36,6 @@
       "pci_passthrough:alias": "gpu-l4:{{ gpu_validation_flavor_gpus }}"
       "hw:pci_numa_affinity_policy": "preferred"
       "hw:hide_hypervisor_id": "true"
+      "hw:kvm_hidden": "true"
+      "hw:cpu_model": "host-passthrough"
     ca_cert: "{{ gpu_validation_ca_cert_path }}"


### PR DESCRIPTION
If the guest VM's driver detects it is running on a passthrough Physical Function of an SR-IOV capable card, it will require a licensed NVIDIA GRID driver to function, whereas you want to use the standard, non-licensed drivers.

This is a well-known behavior with NVIDIA GPUs.
Passing the device through as a type-PF correctly
describes the hardware to OpenStack, but it doesn't change the fact that the NVIDIA driver inside the guest VM can detect the underlying hypervisor and the nature of the device, and then enforce licensing restrictions.

We have confirmed in testing that we cannot hide the SR-IOV capability from the host OS. This means libvirt and Nova will always see it as a type-PF. The problem, therefore, is not in the OpenStack configuration but in how to prevent the guest driver from detecting that it's running on a virtualized PF.

This is a common challenge, and the solution usually involves masking the hypervisor's presence from the guest VM. In libvirt, which Nova uses, this can often be accomplished by configuring the VM's CPU model and hiding the KVM hypervisor signature.

Add flavor properties to make the virtual machine look as "bare-metal" as possible to the guest operating system.

This should prevent the NVIDIA driver from detecting the virtualized environment and enforcing the GRID license requirement, allowing your standard drivers to work.