### PR TITLE
Fix ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Ansible Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   build:
     name: Ansible Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@v25.9.2
         with:
           setup_python: "true"
           requirements_file: "requirements.yaml"


### PR DESCRIPTION
Pin ansible-lint GHA version to avoid this which just appeared on "main":

```
RuntimeError: Python 3.14 requires ansible-core version >= 2.20.0, and we found 2.19.3
```