### PR TITLE
Add SSH ProxyCommand for accessing VMs through a bastion/hypervisor

### DIFF
--- a/gpu-validation/defaults/main.yaml
+++ b/gpu-validation/defaults/main.yaml
@@ -28,6 +28,9 @@ gpu_validation_security_group: basic
 gpu_validation_floating_ip: 192.168.122.222
 # [string] WARNING Where to (over-)write the ssh key. Must match path in inventory
 gpu_validation_private_key_file: ~/test_keypair.key
+# [string] SSH ProxyCommand for accessing VMs through a bastion/hypervisor
+# Example: '-o ProxyCommand="ssh -W %h:%p -o StrictHostKeyChecking=no -i /path/to/key user@bastion-host"'
+gpu_validation_ssh_proxy_command:
 # [bool] Whether to clean up the VM before running tests
 gpu_validation_pre_cleanup_enabled: true
 # [bool] Whether to clean up the VM after running tests

--- a/gpu-validation/tasks/vm_deploy.yaml
+++ b/gpu-validation/tasks/vm_deploy.yaml
@@ -17,6 +17,7 @@
 - name: Poll for SSH to be available on {{ gpu_validation_vm_name }}
   ansible.builtin.command: |
     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    {{ gpu_validation_ssh_proxy_command | default('') }} \
     -i {{ gpu_validation_private_key_file }} cloud-user@{{ gpu_validation_floating_ip }}
   retries: 60  # 60 * 10 = 10 mins
   delay: 10


### PR DESCRIPTION
**What does this PR do?**
Support for accessing VMs through a bastion host or hypervisor using SSH ProxyCommand, which is essential for environments where VMs are not directly accessible from the pod network (like `gpu-validation` pod). e. g. VMs with private network floating IPs that can be accessed through the host (`gpu-validation` pod can reach the host network). This PR does:

- Adds `gpu_validation_ssh_proxy_command` variable
- Provides a helpful example showing the syntax: `-o ProxyCommand="ssh -W %h:%p -o StrictHostKeyChecking=no -i /path/to/key user@bastion-host"`
- Defaults to empty (undefined), maintaining backward compatibility

The ProxyCommand uses the `-W %h:%p` flag, which tells SSH to forward the connection to the target host (`%h`) and port (`%p`) through the bastion, creating a transparent tunnel.

**Why do we need this PR?**
This is critical for environments where:

- VMs are on private networks (e.g., 192.168.x.x)
- Only the hypervisor/bastion has network access to the VMs
- Ansible is running from a remote machine (not the hypervisor itself)
