### PR TITLE
Fix Hardcoded localhost URLs

### DIFF
--- a/gpu-validation/defaults/main.yaml
+++ b/gpu-validation/defaults/main.yaml
@@ -75,3 +75,5 @@ gpu_validation_workload_userns:  # "--userns=keep-id:uid=1001" for RHAIIS
 gpu_validation_workload_shm_size: "--shm-size=4g"
 # [string] Additional environment variables
 gpu_validation_workload_additional_env: "--env=HF_HUB_OFFLINE=0 --env=VLLM_NO_USAGE_STATS=1"
+# [string] vLLM API URL
+gpu_validation_vllm_api_url: "http://127.0.0.1:8000"

--- a/gpu-validation/tasks/model_download_and_serve.yaml
+++ b/gpu-validation/tasks/model_download_and_serve.yaml
@@ -57,7 +57,7 @@
 
 - name: Wait for vllm API to appear
   ansible.builtin.uri:
-    url: http://localhost:8000/health
+    url: "{{ gpu_validation_vllm_api_url }}/health"
   register: api_result
   until: ("status" in api_result) and (api_result.status == 200)
   retries: 180  # 180 * 10 = 30 mins - this includes the time to download the model
@@ -66,7 +66,7 @@
 
 - name: Wait for vllm metrics endpoint to appear
   ansible.builtin.uri:
-    url: http://localhost:8000/metrics/
+    url: "{{ gpu_validation_vllm_api_url }}/metrics/"
   register: metrics_result
   until: ("status" in metrics_result) and (metrics_result.status == 200)
   retries: 12  # 12 * 10 = 2 mins after API appears

--- a/gpu-validation/tasks/model_performance.yaml
+++ b/gpu-validation/tasks/model_performance.yaml
@@ -2,6 +2,7 @@
 - name: Run the model performance check script
   ansible.builtin.command: /tmp/scripts/model_performance_check.sh
   environment:
+    URL: "{{ gpu_validation_vllm_api_url }}"
     MODEL_NAME: "{{ gpu_validation_model_name }}"
   register: performance_script_output
   changed_when: false


### PR DESCRIPTION
**What does this PR do?**
Fix Hardcoded localhost URLs (IPv6/IPv4 Problem).

- TASK [gpu-validation : Wait for vllm API to appear]
- TASK [gpu-validation : Wait for vllm metrics endpoint to appear]
- TASK [gpu-validation : Run the model performance check script]

**Why do we need this PR?**
The playbook had hardcoded URLs scattered across multiple files using http://localhost:8000, which caused the following problems:

- localhost vs 127.0.0.1 resolution issue: localhost was resolving to IPv6 ::1, but vLLM was only listening on IPv4
- Different tasks used different URL formats
- Users couldn't easily change the API URL without editing multiple files

 I added a new centralized variable `gpu_validation_vllm_api_url`