### PR TITLE
Re-use edpm-ansible driver installation code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 tls-ca-bundle.pem
 creds.yaml
 inventory-local
+vars-local.yaml
 my-AnsibleTestCR.yaml
+main*.xml

--- a/gpu-validation/tasks/main.yaml
+++ b/gpu-validation/tasks/main.yaml
@@ -3,15 +3,9 @@
   become: true
   ansible.builtin.import_tasks: setup.yaml
 
-- name: Nvidia Setup
+- name: Nvidia Setup (Use the edpm_accel_drivers role to install the NVIDIA driver in our VM)
   ansible.builtin.include_role:
-    name: nvidia_driver
-    apply:
-      become: true
-  vars:
-    nvidia_driver_module_version: "latest-dkms"
-    nvidia_driver_install_management_library: false
-
+    name: osp.edpm.edpm_accel_drivers
 
 - name: Check GPUs
   ansible.builtin.import_tasks: gpus.yaml

--- a/gpu-validation/vars/main.yaml
+++ b/gpu-validation/vars/main.yaml
@@ -1,0 +1,5 @@
+---
+edpm_accel_drivers_install_nvidia: true
+edpm_accel_drivers_nvidia_repo_url: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/
+edpm_accel_drivers_nvidia_repo_gpgkey: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/D42D0685.pub
+edpm_accel_drivers_nvidia_dnf_module_stream: latest-dkms

--- a/main.yaml
+++ b/main.yaml
@@ -11,7 +11,8 @@
 
 - name: GPU Validation
   hosts: target_nodes
-  gather_facts: false
+  gather_subset:
+    - min
   roles:
     - gpu-validation
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,7 +4,4 @@ collections:
     version: ">=2.4.1"
   - name: community.general
     version: ">=10.0.0"
-roles:
-  - name: nvidia_driver
-    src: https://github.com/rhos-vaf/gpu-drivers-ansible.git
-    version: main
+  - name: git+https://github.com/openstack-k8s-operators/edpm-ansible.git


### PR DESCRIPTION
* This is using the edpm-ansible role for an unintended purpose
* But it means we don't have to maintain a second code base