### PR TITLE
Make GPU PCI alias configurable

### DIFF
--- a/gpu-validation/defaults/main.yaml
+++ b/gpu-validation/defaults/main.yaml
@@ -17,6 +17,8 @@ gpu_validation_flavor_vcpus: 4
 gpu_validation_flavor_disk: 80
 # [string] Number of GPUs for the flavor
 gpu_validation_flavor_gpus: 1
+# [string] PCI alias name for GPU device assignment
+gpu_validation_pci_alias: gpu-l4
 
 # [string] Keypair to use when creating the VM
 gpu_validation_key_name: gpu-validation

--- a/gpu-validation/tasks/vm_image.yaml
+++ b/gpu-validation/tasks/vm_image.yaml
@@ -33,7 +33,7 @@
     vcpus: "{{ gpu_validation_flavor_vcpus }}"
     disk: "{{ gpu_validation_flavor_disk }}"
     extra_specs:
-      "pci_passthrough:alias": "gpu-l4:{{ gpu_validation_flavor_gpus }}"
+      "pci_passthrough:alias": "{{ gpu_validation_pci_alias }}:{{ gpu_validation_flavor_gpus }}"
       "hw:pci_numa_affinity_policy": "preferred"
       "hw:hide_hypervisor_id": "true"
       "hw:kvm_hidden": "true"


### PR DESCRIPTION
Replace hardcoded `gpu-l4` alias with gpu_validation_pci_alias variable to support different GPU types and deployment methods (passthrough or vGPU). Defaults to 'gpu-l4' for backward compatibility.