### PR TITLE
Add reboot detection after GPU driver installation

### DIFF
--- a/gpu-validation/defaults/main.yaml
+++ b/gpu-validation/defaults/main.yaml
@@ -77,3 +77,8 @@ gpu_validation_workload_shm_size: "--shm-size=4g"
 gpu_validation_workload_additional_env: "--env=HF_HUB_OFFLINE=0 --env=VLLM_NO_USAGE_STATS=1"
 # [string] vLLM API URL
 gpu_validation_vllm_api_url: "http://127.0.0.1:8000"
+
+# [int] Reboot timeout in seconds
+gpu_validation_reboot_timeout: 3600
+# [int] Post-reboot delay in seconds
+gpu_validation_reboot_post_delay: 60

--- a/gpu-validation/tasks/main.yaml
+++ b/gpu-validation/tasks/main.yaml
@@ -7,6 +7,9 @@
   ansible.builtin.include_role:
     name: osp.edpm.edpm_accel_drivers
 
+- name: Reboot if system updates require it
+  ansible.builtin.import_tasks: reboot_if_needed.yaml
+
 - name: Check GPUs
   ansible.builtin.import_tasks: gpus.yaml
 - name: GPUs Assertions  # noqa: ignore-errors

--- a/gpu-validation/tasks/reboot_if_needed.yaml
+++ b/gpu-validation/tasks/reboot_if_needed.yaml
@@ -1,0 +1,25 @@
+---
+- name: Make sure yum-utils is installed
+  become: true
+  ansible.builtin.dnf:
+    name: yum-utils
+    state: present
+
+- name: Check if reboot is required with needs-restarting
+  become: true
+  ansible.builtin.command: needs-restarting -r
+  register: _gpu_validation_needs_restarting
+  changed_when: false
+  failed_when: _gpu_validation_needs_restarting.rc >= 2
+
+- name: Print return information from needs-restarting
+  ansible.builtin.debug:
+    var: _gpu_validation_needs_restarting.stdout
+
+- name: Reboot to apply system updates
+  become: true
+  ansible.builtin.reboot:
+    msg: "Rebooting to apply kernel and driver updates"
+    reboot_timeout: "{{ gpu_validation_reboot_timeout }}"
+    post_reboot_delay: "{{ gpu_validation_reboot_post_delay }}"
+  when: _gpu_validation_needs_restarting.rc == 1


### PR DESCRIPTION
**What does this PR do?**
Uses `needs-restarting` to detect when kernel or driver updates require a reboot. Automatically reboots the test VM to load new kernel modules after driver installation.

**Why do we need this PR?**
After the driver installation with the `edpm_accel_drivers` role, the next task `- name: Run nvidia-smi to list NVIDIA GPUs and count them` tries to use `nvidia-smi`, which fails because the NVIDIA driver is not loaded yet.