### PR TITLE
Make instance wait configurable

### DIFF
--- a/gpu-validation/defaults/main.yaml
+++ b/gpu-validation/defaults/main.yaml
@@ -17,6 +17,8 @@ gpu_validation_flavor_vcpus: 4
 gpu_validation_flavor_disk: 80
 # [string] Number of GPUs for the flavor
 gpu_validation_flavor_gpus: 1
+# [string] Time to wait for VM to become created, seconds
+gpu_validation_server_timeout: 180
 
 # [string] Keypair to use when creating the VM
 gpu_validation_key_name: gpu-validation

--- a/gpu-validation/tasks/vm_deploy.yaml
+++ b/gpu-validation/tasks/vm_deploy.yaml
@@ -13,6 +13,7 @@
     security_groups:
       - "{{ gpu_validation_security_group }}"
     ca_cert: "{{ gpu_validation_ca_cert_path }}"
+    timeout: "{{ gpu_validation_server_timeout }}"
 
 - name: Poll for SSH to be available on {{ gpu_validation_vm_name }}
   ansible.builtin.command: |


### PR DESCRIPTION
For DCN setups, it could take more time for VM to come up (network-vif-plugged takes time). Add var
gpu_validation_server_timeout with the same default value as the os server module provides.